### PR TITLE
Chore: 새 백엔드 API 엔드포인트 'api/vi'에 맞게 BASE_URL 수정

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,15 +1,13 @@
 import axios, { AxiosRequestConfig } from "axios";
 
 const BASE_URL = import.meta.env.VITE_BASE_URL;
-const API_BASE_URL =
-  import.meta.env.MODE === "development" ? `${BASE_URL}/api` : `${BASE_URL}`;
 const DEFAULT_TIMEOUT = 30000;
 
-type RequestMethod = "get" | "post" | "put" | "delete";
+type RequestMethod = "get" | "post" | "put" | "delete" | "patch";
 
 export const createClient = (config?: AxiosRequestConfig) => {
   const axiosInstance = axios.create({
-    baseURL: API_BASE_URL,
+    baseURL: `${BASE_URL}/api/v1`,
     timeout: DEFAULT_TIMEOUT,
     headers: {
       "Content-Type": "application/json"
@@ -38,6 +36,9 @@ export const requestHandler = async <T>(
       break;
     case "put":
       response = await httpClient.put(url, payload);
+      break;
+    case "patch":
+      response = await httpClient.patch(url, payload);
       break;
     case "delete":
       response = await httpClient.delete(url);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
       "/api": {
         target: process.env.VITE_BASE_URL,
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ""),
         secure: false,
         ws: true
       }


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 새 백엔드 API 엔드포인트 ```'api/vi'```에 맞게 BASE_URL 수정하였습니다.
- ```patch method``` 추가

### PR Point
- proxy 설정 변경 ('/api로 시작할 때 'api'를 빈 문자열로 변경하는 로직 삭제)


closed #54 
