### PR TITLE
Refactor/sign, Login 페이지 UI 수정

### DIFF
--- a/src/__tests__/__snapshots__/theme.test.ts.snap
+++ b/src/__tests__/__snapshots__/theme.test.ts.snap
@@ -32,6 +32,7 @@ exports[`Theme Object should match the theme snapshot 1`] = `
     "small": {
       "height": "32px",
       "padding": "16px",
+      "width": "105px",
     },
   },
   "buttonVariant": {

--- a/src/__tests__/theme.test.ts
+++ b/src/__tests__/theme.test.ts
@@ -57,7 +57,7 @@ describe("Theme Object", () => {
 
   test.each([
     ["large", { padding: "16px", height: "48px", width: "314px" }],
-    ["small", { padding: "16px", height: "32px" }]
+    ["small", { padding: "16px", height: "32px", width: "105px" }]
   ] as [ButtonSize, { padding: string; height: string; width?: string }][])(
     "should have correct button value for %s",
     (buttonSize, expectedValue) => {

--- a/src/components/common/InputField/Text/AuthInput.tsx
+++ b/src/components/common/InputField/Text/AuthInput.tsx
@@ -33,9 +33,13 @@ const InputContainer = styled.div`
 `;
 
 const TextFieldWrapper = styled(TextField)<{ width?: string }>`
+  && {
+    margin: 0;
+  }
   & .MuiFormLabel-root.Mui-focused {
     color: ${({ theme }) => theme.color.primary};
   }
+
   & .MuiOutlinedInput-root {
     & .MuiOutlinedInput-notchedOutline {
       transition: border-color 0.5s ease;

--- a/src/components/common/InputField/Text/AuthInput.tsx
+++ b/src/components/common/InputField/Text/AuthInput.tsx
@@ -41,7 +41,7 @@ const TextFieldWrapper = styled(TextField)<{ width?: string }>`
       transition: border-color 0.5s ease;
     }
     &:hover .MuiOutlinedInput-notchedOutline {
-      border-color: ${({ theme }) => theme.color.box};
+      border-color: ${({ theme }) => theme.color.primary};
     }
     &.Mui-focused .MuiOutlinedInput-notchedOutline {
       border-color: ${({ theme }) => theme.color.primary};

--- a/src/components/common/InputField/Text/AuthInput.tsx
+++ b/src/components/common/InputField/Text/AuthInput.tsx
@@ -2,6 +2,7 @@ import { TextField } from "@mui/material";
 import styled from "styled-components";
 
 interface AuthInputProps {
+  placeholder: string;
   label: string;
   name: string;
   type?: string;
@@ -14,13 +15,15 @@ const AuthInput = (props: AuthInputProps) => {
     <InputContainer>
       <TextFieldWrapper
         label={props.label}
-        required
-        name={props.name}
-        margin="normal"
-        autoFocus
         type={props.type}
         helperText={props.helperText}
         width={props.width}
+        name={props.name}
+        placeholder={props.placeholder}
+        margin="normal"
+        required
+        autoFocus
+        multiline
       />
     </InputContainer>
   );
@@ -52,7 +55,7 @@ const TextFieldWrapper = styled(TextField)<{ width?: string }>`
     }
   }
   & .MuiInputBase-input::placeholder {
-    color: ${({ theme }) => theme.color.box};
+    color: ${({ theme }) => theme.color.text};
   }
   & .MuiFormHelperText-root {
     color: ${({ theme }) => theme.color.error};

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,8 +11,18 @@ function Login() {
       <Container>
         <ImageWrapper className="logo" src={Logo} />
 
-        <AuthInput label="이메일" name="email" type="email" />
-        <AuthInput label="비밀번호" name="password" type="password" />
+        <AuthInput
+          label="이메일"
+          name="email"
+          type="email"
+          placeholder="example@naver.com"
+        />
+        <AuthInput
+          label="비밀번호"
+          name="password"
+          type="password"
+          placeholder="비밀번호"
+        />
 
         <CustomButton size="large" variant="contained">
           로그인

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -3,6 +3,7 @@ import Logo from "../assets/images/Logo.png";
 import AuthInput from "@/components/common/InputField/Text/AuthInput";
 import CustomButton from "@/components/common/Button/CustomButton";
 import { Link } from "react-router-dom";
+
 const Container = styled.div`
   width: 100%;
   max-width: 600px;
@@ -33,13 +34,15 @@ const LinkWrapper = styled.div`
     text-decoration: none;
   }
   color: ${({ theme }) => theme.color.text};
+  margin-top: 10px;
 `;
 
 const FlexContainer = styled.div`
+  width: 314px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  width: 314px;
+  gap: 20px;
 `;
 
 function Signup() {
@@ -50,13 +53,13 @@ function Signup() {
         <FlexContainer>
           <AuthInput label="닉네임" name="nickname" type="text" width="212px" />
           <CustomButton size="small" variant="outlined">
-            중복확인
+            <span className="b2">중복확인</span>
           </CustomButton>
         </FlexContainer>
         <FlexContainer>
           <AuthInput label="이메일" name="email" type="email" width="212px" />
           <CustomButton size="small" variant="outlined">
-            중복확인
+            <span className="b2">중복확인</span>
           </CustomButton>
         </FlexContainer>
         <AuthInput label="비밀번호" name="password" type="password" />

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -51,19 +51,41 @@ function Signup() {
       <Container>
         <ImageWrapper className="logo" src={Logo} />
         <FlexContainer>
-          <AuthInput label="닉네임" name="nickname" type="text" width="212px" />
+          <AuthInput
+            label="닉네임"
+            name="nickname"
+            type="text"
+            width="212px"
+            placeholder="닉네임을 입력하세요"
+          />
           <CustomButton size="small" variant="outlined">
             <span className="b2">중복확인</span>
           </CustomButton>
         </FlexContainer>
         <FlexContainer>
-          <AuthInput label="이메일" name="email" type="email" width="212px" />
+          <AuthInput
+            label="이메일"
+            name="email"
+            type="email"
+            width="212px"
+            placeholder="example@naver.com"
+          />
           <CustomButton size="small" variant="outlined">
             <span className="b2">중복확인</span>
           </CustomButton>
         </FlexContainer>
-        <AuthInput label="비밀번호" name="password" type="password" />
-        <AuthInput label="비밀번호 확인" name="passwordCheck" type="password" />
+        <AuthInput
+          label="비밀번호"
+          name="password"
+          type="password"
+          placeholder="비밀번호"
+        />
+        <AuthInput
+          label="비밀번호 확인"
+          name="passwordCheck"
+          type="password"
+          placeholder="비밀번호 확인"
+        />
 
         <CustomButton size="large" variant="contained">
           가입하기

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -15,7 +15,7 @@ const Container = styled.div`
   padding: 0 20px;
   margin: 0 auto;
   box-sizing: border-box;
-  gap: 15px;
+  gap: 20px;
 `;
 
 const ImageWrapper = styled.img`

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -115,7 +115,8 @@ export const theme: Theme = {
     },
     small: {
       padding: "16px",
-      height: "32px"
+      height: "32px",
+      width: "105px"
     }
   },
   borderRadius: {


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 회원가입 , 로그인 페이지 전체적인 스타일 수정

### PR Point
- 중복확인 버튼 간격 수정
- 전체 요소 간격 수정
- AuthInput에 placeholder 속성추가
- Login, Signup의 AuthInput에 알맞는 placeholder 설정

### 📸 스크린샷
<img width="436" alt="image" src="https://github.com/user-attachments/assets/62068ff0-da2d-4646-9395-6e13eb46f6d3">
<img width="431" alt="image" src="https://github.com/user-attachments/assets/fb6b3bfa-1646-4fde-8a36-21ecf097b666">
<img width="472" alt="image" src="https://github.com/user-attachments/assets/471bb275-c844-4aea-aeef-ddbe24a86d72">


closed #70 
