### PR TITLE
Refactor/log in

### DIFF
--- a/src/components/common/InputField/Text/AuthInput.tsx
+++ b/src/components/common/InputField/Text/AuthInput.tsx
@@ -51,7 +51,7 @@ const TextFieldWrapper = styled(TextField)<{ width?: string }>`
     }
   }
   & .MuiInputBase-input::placeholder {
-    color: ${({ theme }) => theme.color.box};
+    color: ${({ theme }) => theme.color.text};
   }
   & .MuiFormHelperText-root {
     color: ${({ theme }) => theme.color.error};

--- a/src/components/common/InputField/Text/AuthInput.tsx
+++ b/src/components/common/InputField/Text/AuthInput.tsx
@@ -2,6 +2,7 @@ import { TextField } from "@mui/material";
 import styled from "styled-components";
 
 interface AuthInputProps {
+  placeholder: string;
   label: string;
   name: string;
   type?: string;
@@ -14,13 +15,15 @@ const AuthInput = (props: AuthInputProps) => {
     <InputContainer>
       <TextFieldWrapper
         label={props.label}
-        required
-        name={props.name}
-        margin="normal"
-        autoFocus
         type={props.type}
         helperText={props.helperText}
         width={props.width}
+        name={props.name}
+        placeholder={props.placeholder}
+        margin="normal"
+        required
+        autoFocus
+        multiline
       />
     </InputContainer>
   );

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,8 +11,18 @@ function Login() {
       <Container>
         <ImageWrapper className="logo" src={Logo} />
 
-        <AuthInput label="이메일" name="email" type="email" />
-        <AuthInput label="비밀번호" name="password" type="password" />
+        <AuthInput
+          label="이메일"
+          name="email"
+          type="email"
+          placeholder="example@naver.com"
+        />
+        <AuthInput
+          label="비밀번호"
+          name="password"
+          type="password"
+          placeholder="비밀번호"
+        />
 
         <CustomButton size="large" variant="contained">
           로그인


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 로그인페이지의 이메일과 비밀번호의 placeholder 설정

### PR Point
- 로그인 페이지의 AuthInput 컴포넌트의 placeholder 속성 추가

### 📸 스크린샷
<img width="471" alt="image" src="https://github.com/user-attachments/assets/04177e42-2c40-45b1-af19-dff0abeb638f">

closed #72 
