### PR TITLE
Design: 카테고리 드롭다운 UI

### DIFF
--- a/src/components/Icon/IconButton.tsx
+++ b/src/components/Icon/IconButton.tsx
@@ -1,0 +1,20 @@
+import { ICONS } from "@/constants/assets";
+import { ColorKey } from "@/style/theme";
+import { HTMLAttributes } from "react";
+import Icon from "./Icon";
+
+interface Props extends HTMLAttributes<HTMLButtonElement> {
+  name: keyof typeof ICONS;
+  size: string;
+  color: ColorKey;
+}
+
+const IconButton = ({ name, size, color, ...props }: Props) => {
+  return (
+    <button {...props}>
+      <Icon name={name} color={color} size={size} />
+    </button>
+  );
+};
+
+export default IconButton;

--- a/src/components/common/InputField/dropdown/CategoryDropdown.tsx
+++ b/src/components/common/InputField/dropdown/CategoryDropdown.tsx
@@ -12,7 +12,7 @@ interface Props {
   onEditAction?: () => void; // 액션 수정 기능, 삭제 기능
 }
 
-const RoutineDropdown = ({
+const CategoryDropdown = ({
   category,
   actions,
   modifyEnabled = false,
@@ -144,4 +144,4 @@ const slideUp = keyframes`
   }
 `;
 
-export default RoutineDropdown;
+export default CategoryDropdown;

--- a/src/components/common/InputField/dropdown/RoutineDropdown.tsx
+++ b/src/components/common/InputField/dropdown/RoutineDropdown.tsx
@@ -1,0 +1,147 @@
+import IconButton from "@/components/Icon/IconButton";
+import { IAction } from "@/models/routine.model";
+import { LineClamp } from "@/style/global";
+import { useState } from "react";
+import styled, { keyframes } from "styled-components";
+
+interface Props {
+  category: string;
+  actions: IAction[];
+  modifyEnabled?: boolean;
+  onEditCategory?: () => void; // 카테고리 수정, 삭제 기능
+  onEditAction?: () => void; // 액션 수정 기능, 삭제 기능
+}
+
+const RoutineDropdown = ({
+  category,
+  actions,
+  modifyEnabled = false,
+  onEditCategory,
+  onEditAction
+}: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleCategory = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (onEditCategory) {
+      onEditCategory();
+    }
+  };
+
+  return (
+    <Wrapper>
+      <DropdownBox onClick={handleToggle}>
+        {category}
+        <Buttons $isOpen={isOpen}>
+          {modifyEnabled && (
+            <IconButton
+              name="dots"
+              color="text"
+              size="24px"
+              onClick={handleCategory}
+            />
+          )}
+          <IconButton
+            name="arrowDown"
+            color="text"
+            size="24px"
+            onClick={() => {}}
+            className="arrow-button"
+          />
+        </Buttons>
+      </DropdownBox>
+      <OptionBox $isOpen={isOpen}>
+        {actions.map((action) => (
+          <Action key={action.actionId}>
+            <Text>
+              <p className="b3">{action.actionName}</p>
+              <LineClamp $line={1} className="b2">
+                {action.countOrMinutes} {action.sets}세트
+              </LineClamp>
+            </Text>
+            {modifyEnabled && (
+              <IconButton
+                name="dots"
+                color="text"
+                size="24px"
+                onClick={onEditAction}
+              />
+            )}
+          </Action>
+        ))}
+      </OptionBox>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const DropdownBox = styled.div`
+  display: flex;
+  align-items: center;
+  height: 60px;
+  color: ${({ theme }) => theme.color.primary};
+  font-weight: 800;
+  cursor: pointer;
+  border-bottom: 1px solid ${({ theme }) => theme.color.gray2};
+
+  .modify-button {
+    margin: 4px;
+  }
+`;
+
+const Buttons = styled.div<{ $isOpen: boolean }>`
+  margin-left: auto;
+  display: flex;
+  gap: 10px;
+
+  .arrow-button {
+    transform: rotate(${({ $isOpen }) => ($isOpen ? "180deg" : "0")});
+    transition: transform 0.3s ease-in-out;
+  }
+`;
+
+const OptionBox = styled.ul<{ $isOpen: boolean }>`
+  overflow: hidden;
+  animation: ${({ $isOpen }) => ($isOpen ? slideDown : slideUp)} 0.3s
+    ease-in-out forwards;
+`;
+
+const Action = styled.li`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 70px;
+`;
+
+const Text = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const slideDown = keyframes`
+  0% {
+    max-height: 0;
+  }
+  100% {
+    max-height: 1000px; // 충분히 큰 값(Action 12개까지 가능)
+  }
+`;
+
+const slideUp = keyframes`
+  0% {
+    max-height: 1000px;
+  }
+  100% {
+    max-height: 0;
+  }
+`;
+
+export default RoutineDropdown;

--- a/src/constants/assets.tsx
+++ b/src/constants/assets.tsx
@@ -5,7 +5,7 @@ import { HiChartBar } from "react-icons/hi2";
 import {
   IoIosArrowBack,
   IoIosArrowDown,
-  IoIosMore,
+  IoMdMore,
   IoMdPerson
 } from "react-icons/io";
 import { IoClose, IoLogOutOutline, IoSearch } from "react-icons/io5";
@@ -32,5 +32,5 @@ export const ICONS = {
   x: IoClose,
   search: IoSearch,
   arrowDown: IoIosArrowDown,
-  dots: IoIosMore
+  dots: IoMdMore
 };

--- a/src/constants/assets.tsx
+++ b/src/constants/assets.tsx
@@ -2,7 +2,12 @@ import { CiBellOn, CiDumbbell } from "react-icons/ci";
 import { FaPeoplePulling } from "react-icons/fa6";
 import { GrHomeRounded } from "react-icons/gr";
 import { HiChartBar } from "react-icons/hi2";
-import { IoIosArrowBack, IoMdPerson } from "react-icons/io";
+import {
+  IoIosArrowBack,
+  IoIosArrowDown,
+  IoIosMore,
+  IoMdPerson
+} from "react-icons/io";
 import { IoClose, IoLogOutOutline, IoSearch } from "react-icons/io5";
 import { LuPencilLine } from "react-icons/lu";
 import { PiSunglassesBold } from "react-icons/pi";
@@ -25,5 +30,7 @@ export const ICONS = {
   delete: RiDeleteBin5Line,
   filter: TbArrowsExchange2,
   x: IoClose,
-  search: IoSearch
+  search: IoSearch,
+  arrowDown: IoIosArrowDown,
+  dots: IoIosMore
 };

--- a/src/models/routine.model.ts
+++ b/src/models/routine.model.ts
@@ -12,3 +12,10 @@ export interface IResponseMessage {
   statusCode: number;
   message: string;
 }
+
+export interface IAction {
+  actionId: number;
+  actionName: string;
+  sets: number;
+  countOrMinutes: string;
+}


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 카테고리 드롭다운 컴포넌트를 제작하였습니다.

### PR Point
- **특히 윤성님 주목** : 변경 전에 아이콘 2개를 배치하는 형식이 좀 지저분하여 더보기 버튼으로 대체하였습니다
- **더보기**를 눌렀을 때 **카테고리 수정, 카테고리 삭제 푸터 모달이 나올 수 있도록** 해야할 것 같습니다
- 변경 후
![image](https://github.com/user-attachments/assets/a806f725-ec20-4789-b773-93d1dadffb8b)
- 변경 전
![image](https://github.com/user-attachments/assets/5aab1462-44ef-4e7b-8ea8-938f4319cfc7)

### 📸 스크린샷
- 닫힌 모습
![image](https://github.com/user-attachments/assets/b7d9de30-f435-484c-9d73-e5643832f0a6)
- 열린 모습
![image](https://github.com/user-attachments/assets/857eee19-2f2d-459d-97a4-0aa268015dfc)

closed #126
