### PR TITLE
Feat: 인증 API를 헤더, 푸터에 연결

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -8,8 +8,7 @@ import {
   ISignup,
   IUserProfile
 } from "@/models/auth.model";
-import { ICoachDetail, IMyPageCoachFormWithSports, IMyPageCoachFormValues } from "@/models/coach.model";
-import { httpClient, createClient, requestHandler } from "./http";
+import { ICoachDetail, IMyPageCoachFormWithSports } from "@/models/coach.model";
 import { AxiosResponse } from "axios";
 import { createClient, httpClient, requestHandler } from "./http";
 

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,5 +1,6 @@
 import { API_PATH } from "@/constants/apiPath";
 import {
+  IAuthResponse,
   ICheckEmailDuplication,
   ICheckNicknameDuplication,
   ICheckPassword,
@@ -8,8 +9,8 @@ import {
   IUserProfile
 } from "@/models/auth.model";
 import { ICoachDetail, IMyPageCoachFormValues } from "@/models/coach.model";
-import { httpClient, createClient, requestHandler } from "./http";
 import { AxiosResponse } from "axios";
+import { createClient, httpClient, requestHandler } from "./http";
 
 export const getProfile = async () => {
   return await requestHandler<IUserProfile>("get", API_PATH.mypage);
@@ -73,4 +74,8 @@ export const editProfile = async (formData: FormData) => {
 
 export const editCoachProfile = async (formData: IMyPageCoachFormValues) => {
   return await requestHandler("put", API_PATH.editMyCoachProfile, formData);
+};
+
+export const getAuth = async () => {
+  return await requestHandler<IAuthResponse>("get", API_PATH.auth);
 };

--- a/src/components/badge/NotificationBadge.tsx
+++ b/src/components/badge/NotificationBadge.tsx
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+
+interface Props {
+  count: number;
+}
+const NotificationBadge = ({ count }: Props) => {
+  return <Wrapper>{count > 99 ? "99+" : count}</Wrapper>;
+};
+
+const Wrapper = styled.div`
+  position: absolute;
+  top: -8px;
+  left: 14px;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  background-color: ${({ theme }) => theme.color.primary};
+  color: ${({ theme }) => theme.color.background};
+  border-radius: 6.25rem;
+
+  font-size: 12px;
+
+  padding: 0.25rem;
+`;
+export default NotificationBadge;

--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -1,4 +1,6 @@
 import Icon from "@/components/Icon/Icon";
+import NotificationBadge from "@/components/badge/NotificationBadge";
+import { useFetchAuth } from "@/hooks/useFetchAuth";
 import useModal from "@/hooks/useModal";
 import { useNavigate } from "react-router-dom";
 import { styled } from "styled-components";
@@ -6,6 +8,7 @@ import Modal from "../modal/Modal";
 import FooterPicker from "../modal/contents/FooterPicker";
 
 const Footer = () => {
+  const { data } = useFetchAuth();
   const navigate = useNavigate();
   const routineModal = useModal();
   const profileModal = useModal();
@@ -56,7 +59,12 @@ const Footer = () => {
           color="text"
           onClick={onClickRoutine}
         />
-        <Icon name="alarm" size="30px" color="text" onClick={onClickAlarm} />
+        <Notification>
+          <Icon name="alarm" size="30px" color="text" onClick={onClickAlarm} />
+          {data && data.countOfNotifications > 0 && (
+            <NotificationBadge count={data?.countOfNotifications} />
+          )}
+        </Notification>
         <Icon
           name="profile"
           size="25px"
@@ -80,5 +88,9 @@ const FooterStyle = styled.footer`
   max-width: 600px;
   height: 60px;
   z-index: 1001; // FooterAbove(Footer 아이콘 클릭 시 모달)보다 앞에 있어 FooterAbove가 가리지 않게 함
+`;
+
+const Notification = styled.div`
+  position: relative;
 `;
 export default Footer;

--- a/src/components/common/Header/LogoHeader.tsx
+++ b/src/components/common/Header/LogoHeader.tsx
@@ -2,10 +2,7 @@ import { useFetchAuth } from "@/hooks/useFetchAuth";
 import { styled } from "styled-components";
 import Logo from "../../../assets/images/Logo.png";
 
-interface Props {
-  nickname?: string;
-}
-const LogoHeader = ({ nickname }: Props) => {
+const LogoHeader = () => {
   const { data } = useFetchAuth();
   return (
     <LogoHeaderStyle>

--- a/src/components/common/Header/LogoHeader.tsx
+++ b/src/components/common/Header/LogoHeader.tsx
@@ -1,21 +1,44 @@
+import { useFetchAuth } from "@/hooks/useFetchAuth";
 import { styled } from "styled-components";
 import Logo from "../../../assets/images/Logo.png";
 
-const LogoHeader = () => {
+interface Props {
+  nickname?: string;
+}
+const LogoHeader = ({ nickname }: Props) => {
+  const { data } = useFetchAuth();
   return (
     <LogoHeaderStyle>
       <img src={Logo} alt="Logo" />
+      {data?.nickname && (
+        <h2>
+          <span>안녕하세요! </span>
+          {data?.nickname}
+          <span>님</span>
+        </h2>
+      )}
     </LogoHeaderStyle>
   );
 };
 
 const LogoHeaderStyle = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   padding: 20px;
   margin: 0;
 
   img {
     width: 90px;
     height: 50px;
+  }
+
+  h2 {
+    display: flex;
+    gap: 6px;
+  }
+  span {
+    font-size: 12px;
   }
 `;
 

--- a/src/constants/apiPath.ts
+++ b/src/constants/apiPath.ts
@@ -18,5 +18,6 @@ export const API_PATH = {
   notification: "/notifications",
   matchMembers: "/coaches/members",
   matchMember: "/coaches/member",
-  patchMember: "/coaches/matched/members"
+  patchMember: "/coaches/matched/members",
+  auth: "/auth"
 };

--- a/src/hooks/useFetchAuth.ts
+++ b/src/hooks/useFetchAuth.ts
@@ -1,0 +1,11 @@
+import { getAuth } from "@/api/auth.api";
+import { useQuery } from "@tanstack/react-query";
+
+export const useFetchAuth = () => {
+  const { data, isError, isLoading } = useQuery({
+    queryKey: ["getAuth"],
+    queryFn: getAuth
+  });
+
+  return { data, isError, isLoading };
+};

--- a/src/hooks/useFetchAuth.ts
+++ b/src/hooks/useFetchAuth.ts
@@ -4,7 +4,8 @@ import { useQuery } from "@tanstack/react-query";
 export const useFetchAuth = () => {
   const { data, isError, isLoading } = useQuery({
     queryKey: ["getAuth"],
-    queryFn: getAuth
+    queryFn: getAuth,
+    staleTime: 1000 * 60 * 2
   });
 
   return { data, isError, isLoading };

--- a/src/models/auth.model.ts
+++ b/src/models/auth.model.ts
@@ -46,3 +46,9 @@ export interface ICheckNicknameDuplication {
 export interface ICheckPassword {
   password: string;
 }
+
+export interface IAuthResponse {
+  isLogin: boolean;
+  nickname: string | null;
+  countOfNotifications: number;
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,4 @@
 import PopularCoaches from "@/components/coach/PopularCoaches";
-import Search from "@/components/common/InputField/search/Search";
 import SportsList from "@/components/sports/SportsList";
 import useHome from "@/hooks/useHome";
 import { WhiteSpace } from "@/style/global";
@@ -13,8 +12,6 @@ const Home = () => {
 
   return (
     <HomeStyle>
-      <Search placeholder="코치명을 검색하세요" />
-      <WhiteSpace $height={40} />
       <SportsList sportsList={data.sports} />
       <WhiteSpace $height={80} />
       <PopularCoaches popularCoaches={data.coaches} />


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 인증 API를 헤더, 푸터에 연결하여 알람 뱃지, 닉네임 화면에 표시

### PR Point
- 인증 API 
- staleTime : 2분 (알람, 닉네임이 신선하다고 생각하는 시간)

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/5bfb8049-5535-4dee-bd13-f3e4b7f16f04)
![image](https://github.com/user-attachments/assets/9b2923a2-4042-45c6-bf57-961f69fc300e)


closed #163 
