### PR TITLE
Feat: 좋아요 등록, 해제에 invalidateQueries 추가

### DIFF
--- a/src/hooks/queries/useLikes.ts
+++ b/src/hooks/queries/useLikes.ts
@@ -7,6 +7,7 @@ export const useLikePost = (id: number) => {
   const { mutate, isError } = useMutation<IResponseMessage, Error, number>({
     mutationFn: (id: number) => likePost(id),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["getHomeData"] });
       queryClient.invalidateQueries({ queryKey: ["getCoachDetail", id] });
     }
   });
@@ -21,6 +22,7 @@ export const useUnLikePost = (id: number) => {
   const { mutate, isError } = useMutation<IResponseMessage, Error, number>({
     mutationFn: (id: number) => unlikePost(id),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["getHomeData"] });
       queryClient.invalidateQueries({ queryKey: ["getCoachDetail", id] });
     }
   });


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 문제상황
하트를 누르고 다른 페이지에 갔다가 navigate(-1)을 하면 이전 상태로 돌아가면서 하트값이 반대로 렌더링됨
백엔드에서는 정상적으로 응답이 옴

https://github.com/user-attachments/assets/a90c58a9-ad03-4276-8d26-e8404b19e821

- 해결방법
- ```invalidateQueries```로 **좋아요 누르자마자 상태 업데이트**
![image](https://github.com/user-attachments/assets/a34eff2e-6795-4007-8481-108b5c245a95)




### PR Point
- 우선 invalidationQueries로 방어를 했지만 별로 좋지 않은 방법 같아서, 
- 추후, 뒤로 가기 눌렀을 때 navigate(-1)을 하는 것을 수정하고자 함

closed #180 
