### PR TITLE
Feat: 코치 리스트 필터들을 쿼리 스트링으로 추가

### DIFF
--- a/src/api/coach.api.ts
+++ b/src/api/coach.api.ts
@@ -10,26 +10,26 @@ import { IResponseMessage } from "@/models/responseMessage.model";
 import qs from "qs";
 import { requestHandler } from "./http";
 
-export const getCoachAll = ({ filter, page }: IAllCoachList) => {
-  const { search, sportsIdList, filterId } = filter;
+export const getCoachAll = ({ filter, page }: IAllCoachList, sort: string) => {
+  const { search, sportsIdList } = filter;
 
   let latest: boolean | undefined;
   let review: boolean | undefined;
   let liked: boolean | undefined;
   let my: boolean | undefined;
 
-  switch (filterId) {
-    case 0:
-      latest = true;
-      break;
-    case 1:
+  switch (sort) {
+    case "review":
       review = true;
       break;
-    case 2:
+    case "liked":
       liked = true;
       break;
-    case 3:
+    case "my":
       my = true;
+      break;
+    default:
+      latest = true;
       break;
   }
 

--- a/src/api/coach.api.ts
+++ b/src/api/coach.api.ts
@@ -1,22 +1,16 @@
 import { API_PATH } from "@/constants/apiPath";
-import {
-  IAllCoachList,
-  ICoachDetail,
-  ICoachList,
-  ISimpleCoach
-} from "@/models/coach.model";
+import { ICoachDetail, ICoachList, ISimpleCoach } from "@/models/coach.model";
 import { IMatchMembers } from "@/models/member.model";
 import { IResponseMessage } from "@/models/responseMessage.model";
 import qs from "qs";
 import { requestHandler } from "./http";
 
 export const getCoachAll = (
-  { filter, page }: IAllCoachList,
+  page: number,
+  search: string | null,
   sort: string,
   sportsIds: number[]
 ) => {
-  const { search } = filter;
-
   let latest: boolean | undefined;
   let review: boolean | undefined;
   let liked: boolean | undefined;

--- a/src/api/coach.api.ts
+++ b/src/api/coach.api.ts
@@ -10,8 +10,12 @@ import { IResponseMessage } from "@/models/responseMessage.model";
 import qs from "qs";
 import { requestHandler } from "./http";
 
-export const getCoachAll = ({ filter, page }: IAllCoachList, sort: string) => {
-  const { search, sportsIdList } = filter;
+export const getCoachAll = (
+  { filter, page }: IAllCoachList,
+  sort: string,
+  sportsIds: number[]
+) => {
+  const { search } = filter;
 
   let latest: boolean | undefined;
   let review: boolean | undefined;
@@ -33,16 +37,9 @@ export const getCoachAll = ({ filter, page }: IAllCoachList, sort: string) => {
       break;
   }
 
-  let formattedSportsId;
-  if (sportsIdList?.includes(0)) {
-    formattedSportsId = null;
-  } else {
-    formattedSportsId = sportsIdList?.join(",");
-  }
-
   const query = qs.stringify(
     {
-      sports: formattedSportsId,
+      sports: sportsIds.length === 0 ? null : sportsIds.join(","),
       search,
       latest,
       review,

--- a/src/components/coach/CaochListFilter.tsx
+++ b/src/components/coach/CaochListFilter.tsx
@@ -7,16 +7,11 @@ import Modal from "../common/modal/Modal";
 import FilterPicker from "../common/modal/contents/FilterPicker";
 
 interface Props {
-  sportsIdList: number[];
   singleFilter: (id: number) => void;
   multiFilter: (id: number) => void;
 }
 
-const CoachListFilter = ({
-  sportsIdList,
-  singleFilter,
-  multiFilter
-}: Props) => {
+const CoachListFilter = ({ singleFilter, multiFilter }: Props) => {
   const { isModal, closeModal, handleModal } = useModal();
 
   // 종목 필터에 "전체" 추가한 배열
@@ -28,6 +23,8 @@ const CoachListFilter = ({
   const [searchParams] = useSearchParams();
   const sort = searchParams.get("sort") ?? "latest";
 
+  const sportsIds = searchParams.get("sportsIds")?.split(",").map(Number) ?? [];
+
   return (
     <CoachListFilterStyle>
       <Icon name="filter" size="18px" color="text" onClick={handleModal} />
@@ -37,7 +34,7 @@ const CoachListFilter = ({
       </SortFilter>
       {/* 종목 필터 */}
       <SportsFilter>
-        {sportsIdList.map((id) => (
+        {sportsIds.map((id) => (
           <Filter key={id}>
             {
               SPORT_LIST_WITH_TOTAL.find((sport) => sport.sportId === id)
@@ -55,7 +52,6 @@ const CoachListFilter = ({
       {isModal && (
         <Modal position="footer-above" closeModal={closeModal}>
           <FilterPicker
-            sportsIdList={sportsIdList}
             sportListWithTotal={SPORT_LIST_WITH_TOTAL}
             singleFilter={singleFilter}
             multiFilter={multiFilter}

--- a/src/components/coach/CaochListFilter.tsx
+++ b/src/components/coach/CaochListFilter.tsx
@@ -2,7 +2,7 @@ import { filterList, sportList } from "@/data/sportsList";
 import useModal from "@/hooks/useModal";
 import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
-import Icon from "../Icon/Icon";
+import IconButton from "../Icon/IconButton";
 import Modal from "../common/modal/Modal";
 import FilterPicker from "../common/modal/contents/FilterPicker";
 
@@ -27,7 +27,12 @@ const CoachListFilter = ({ singleFilter, multiFilter }: Props) => {
 
   return (
     <CoachListFilterStyle>
-      <Icon name="filter" size="18px" color="text" onClick={handleModal} />
+      <IconButton
+        name="filter"
+        size="18px"
+        color="text"
+        onClick={handleModal}
+      />
       {/* 정렬 필터*/}
       <SortFilter>
         {filterList.find((filter) => sort === filter.parameter)?.name}
@@ -40,7 +45,7 @@ const CoachListFilter = ({ singleFilter, multiFilter }: Props) => {
               SPORT_LIST_WITH_TOTAL.find((sport) => sport.sportId === id)
                 ?.sportName
             }
-            <Icon
+            <IconButton
               name="x"
               size="14px"
               color="primary"

--- a/src/components/coach/CaochListFilter.tsx
+++ b/src/components/coach/CaochListFilter.tsx
@@ -1,19 +1,18 @@
 import { filterList, sportList } from "@/data/sportsList";
 import useModal from "@/hooks/useModal";
+import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 import Icon from "../Icon/Icon";
 import Modal from "../common/modal/Modal";
 import FilterPicker from "../common/modal/contents/FilterPicker";
 
 interface Props {
-  filterId: number;
   sportsIdList: number[];
   singleFilter: (id: number) => void;
   multiFilter: (id: number) => void;
 }
 
 const CoachListFilter = ({
-  filterId,
   sportsIdList,
   singleFilter,
   multiFilter
@@ -26,12 +25,15 @@ const CoachListFilter = ({
     ...sportList
   ];
 
+  const [searchParams] = useSearchParams();
+  const sort = searchParams.get("sort") ?? "latest";
+
   return (
     <CoachListFilterStyle>
       <Icon name="filter" size="18px" color="text" onClick={handleModal} />
       {/* 정렬 필터*/}
       <SortFilter>
-        {filterList.find((filter) => filterId === filter.id)?.name}
+        {filterList.find((filter) => sort === filter.parameter)?.name}
       </SortFilter>
       {/* 종목 필터 */}
       <SportsFilter>
@@ -53,7 +55,6 @@ const CoachListFilter = ({
       {isModal && (
         <Modal position="footer-above" closeModal={closeModal}>
           <FilterPicker
-            filterId={filterId}
             sportsIdList={sportsIdList}
             sportListWithTotal={SPORT_LIST_WITH_TOTAL}
             singleFilter={singleFilter}

--- a/src/components/coach/CaochListFilter.tsx
+++ b/src/components/coach/CaochListFilter.tsx
@@ -2,6 +2,7 @@ import { filterList, sportList } from "@/data/sportsList";
 import useModal from "@/hooks/useModal";
 import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
+import Icon from "../Icon/Icon";
 import IconButton from "../Icon/IconButton";
 import Modal from "../common/modal/Modal";
 import FilterPicker from "../common/modal/contents/FilterPicker";
@@ -27,16 +28,14 @@ const CoachListFilter = ({ singleFilter, multiFilter }: Props) => {
 
   return (
     <CoachListFilterStyle>
-      <IconButton
-        name="filter"
-        size="18px"
-        color="text"
-        onClick={handleModal}
-      />
-      {/* 정렬 필터*/}
-      <SortFilter>
-        {filterList.find((filter) => sort === filter.parameter)?.name}
-      </SortFilter>
+      <SortingFilterButton onClick={handleModal}>
+        <Icon name="filter" size="18px" color="text" />
+        {/* 정렬 필터*/}
+        <SortFilter>
+          {filterList.find((filter) => sort === filter.parameter)?.name}
+        </SortFilter>
+      </SortingFilterButton>
+
       {/* 종목 필터 */}
       <SportsFilter>
         {sportsIds.map((id) => (
@@ -95,5 +94,11 @@ const Filter = styled.button`
   background-color: ${({ theme }) => theme.color.background};
   border-radius: ${({ theme }) => theme.borderRadius.default};
   border: 1px solid ${({ theme }) => theme.color.primary};
+`;
+
+const SortingFilterButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 2px;
 `;
 export default CoachListFilter;

--- a/src/components/coach/Coach.tsx
+++ b/src/components/coach/Coach.tsx
@@ -13,7 +13,7 @@ const Coach = ({ coach }: Props) => {
     <CoachStyle onClick={() => navigate(`/coach/${coach.coachId}`)}>
       <Image src={coach.profileImageUrl || undefined} alt={coach.coachName} />
       <Text>
-        <LineClamp $line={1} className="b3">
+        <LineClamp $line={1} className="name">
           {coach.coachName}
         </LineClamp>
         <LineClamp $line={2} className="desc">
@@ -42,7 +42,7 @@ const Image = styled.img`
   flex-shrink: 0;
   width: 114px;
   height: 114px;
-  border-radius: ${({ theme }) => theme.borderRadius.default};
+  border-radius: 8px;
   object-fit: cover;
 
   @media only screen and (max-width: 500px) {
@@ -55,6 +55,11 @@ const Text = styled.div`
   overflow: hidden;
   flex: 1;
 
+  .name {
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+
   .desc {
     font-size: 12px;
     margin-bottom: 10px;
@@ -65,9 +70,12 @@ const Text = styled.div`
     align-items: center;
     gap: 9px;
 
+    position: absolute;
+    bottom: 0;
+
     li {
       display: inline-flex;
-      font-size: 9px;
+      font-size: 10px;
       padding: 4px 6px;
       border-radius: ${({ theme }) => theme.borderRadius.default};
       color: ${({ theme }) => theme.color.text};

--- a/src/components/coach/CoachList.tsx
+++ b/src/components/coach/CoachList.tsx
@@ -1,17 +1,21 @@
 import useCoachList from "@/hooks/useCoachList";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
+import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 import Coach from "./Coach";
 
 interface Props {
-  filterId: number;
   sportsIdList: number[];
 }
-const CoachList = ({ filterId, sportsIdList }: Props) => {
+const CoachList = ({ sportsIdList }: Props) => {
+  const [searchParams] = useSearchParams();
+  const sort = searchParams.get("sort") ?? "latest";
+
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useCoachList(
     {
-      filter: { filterId, sportsIdList }
-    }
+      filter: { sportsIdList }
+    },
+    sort
   );
 
   const { setTarget } = useIntersectionObserver({

--- a/src/components/coach/CoachList.tsx
+++ b/src/components/coach/CoachList.tsx
@@ -30,11 +30,7 @@ const CoachList = () => {
         <Coach coach={coach} key={coach.coachId} />
       ))}
       <div ref={setTarget}></div>
-      {isFetchingNextPage
-        ? "로딩중..."
-        : hasNextPage
-          ? "다음 페이지 불러오기"
-          : "마지막 페이지"}
+      {isFetchingNextPage && "로딩중..."}
     </CoachListStyle>
   );
 };

--- a/src/components/coach/CoachList.tsx
+++ b/src/components/coach/CoachList.tsx
@@ -4,18 +4,18 @@ import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 import Coach from "./Coach";
 
-interface Props {
-  sportsIdList: number[];
-}
-const CoachList = ({ sportsIdList }: Props) => {
+const CoachList = () => {
   const [searchParams] = useSearchParams();
   const sort = searchParams.get("sort") ?? "latest";
 
+  const sportsIds = searchParams.get("sportsIds")?.split(",").map(Number) ?? [];
+
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useCoachList(
     {
-      filter: { sportsIdList }
+      filter: {}
     },
-    sort
+    sort,
+    sportsIds
   );
 
   const { setTarget } = useIntersectionObserver({

--- a/src/components/coach/CoachList.tsx
+++ b/src/components/coach/CoachList.tsx
@@ -11,9 +11,7 @@ const CoachList = () => {
   const sportsIds = searchParams.get("sportsIds")?.split(",").map(Number) ?? [];
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useCoachList(
-    {
-      filter: {}
-    },
+    null,
     sort,
     sportsIds
   );

--- a/src/components/coach/CoachList.tsx
+++ b/src/components/coach/CoachList.tsx
@@ -6,8 +6,8 @@ import Coach from "./Coach";
 
 const CoachList = () => {
   const [searchParams] = useSearchParams();
-  const sort = searchParams.get("sort") ?? "latest";
 
+  const sort = searchParams.get("sort") ?? "latest";
   const sportsIds = searchParams.get("sportsIds")?.split(",").map(Number) ?? [];
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useCoachList(

--- a/src/components/common/InputField/search/Search.tsx
+++ b/src/components/common/InputField/search/Search.tsx
@@ -33,7 +33,7 @@ const SearchStyle = styled.div`
   input {
     width: 100%;
     border: 1px solid ${({ theme }) => theme.color.text};
-    border-radius: 4px;
+    border-radius: ${({ theme }) => theme.borderRadius.default};
     padding: 12px 30px 12px 20px;
     outline: none;
     transition:

--- a/src/components/common/modal/contents/FilterPicker.tsx
+++ b/src/components/common/modal/contents/FilterPicker.tsx
@@ -1,9 +1,9 @@
 import { filterList } from "@/data/sportsList";
 import { ICoachingSports } from "@/models/sports.model";
+import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 
 interface Props {
-  filterId: number;
   sportsIdList: number[];
   sportListWithTotal: ICoachingSports[]; // "전체"를 포함한 종목 필터
   singleFilter: (id: number) => void;
@@ -11,12 +11,15 @@ interface Props {
 }
 
 const FilterPicker = ({
-  filterId,
   sportsIdList,
   sportListWithTotal,
   singleFilter,
   multiFilter
 }: Props) => {
+  // TODO: 중복된 sort값 훅으로 분리하기
+  const [searchParams] = useSearchParams();
+  const sort = searchParams.get("sort") ?? "latest";
+
   return (
     <FilterPickerStyle>
       <Text>
@@ -27,7 +30,7 @@ const FilterPicker = ({
         {filterList.map((filter) => (
           <Filter
             key={filter.id}
-            $active={filter.id === filterId}
+            $active={filter.parameter === sort}
             onClick={() => singleFilter(filter.id)}
           >
             {filter.name}

--- a/src/components/common/modal/contents/FilterPicker.tsx
+++ b/src/components/common/modal/contents/FilterPicker.tsx
@@ -14,7 +14,7 @@ const FilterPicker = ({
   singleFilter,
   multiFilter
 }: Props) => {
-  // TODO: 중복된 sort값 훅으로 분리하기
+  // TODO: 중복된 쿼리 파라미터 가져오는 부분 훅으로 분리
   const [searchParams] = useSearchParams();
   const sort = searchParams.get("sort") ?? "latest";
   const sportsIds = searchParams.get("sportsIds")?.split(",").map(Number) ?? [];

--- a/src/components/common/modal/contents/FilterPicker.tsx
+++ b/src/components/common/modal/contents/FilterPicker.tsx
@@ -4,14 +4,12 @@ import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
 
 interface Props {
-  sportsIdList: number[];
   sportListWithTotal: ICoachingSports[]; // "전체"를 포함한 종목 필터
   singleFilter: (id: number) => void;
   multiFilter: (id: number) => void;
 }
 
 const FilterPicker = ({
-  sportsIdList,
   sportListWithTotal,
   singleFilter,
   multiFilter
@@ -19,6 +17,8 @@ const FilterPicker = ({
   // TODO: 중복된 sort값 훅으로 분리하기
   const [searchParams] = useSearchParams();
   const sort = searchParams.get("sort") ?? "latest";
+
+  const sportsIds = searchParams.get("sportsIds")?.split(",").map(Number) ?? [];
 
   return (
     <FilterPickerStyle>
@@ -45,7 +45,7 @@ const FilterPicker = ({
         {sportListWithTotal.map((sport) => (
           <Filter
             key={sport.sportId}
-            $active={sportsIdList.includes(sport.sportId)}
+            $active={sportsIds.includes(sport.sportId)}
             onClick={() => multiFilter(sport.sportId)}
           >
             {sport.sportName}

--- a/src/components/common/modal/contents/FilterPicker.tsx
+++ b/src/components/common/modal/contents/FilterPicker.tsx
@@ -17,7 +17,6 @@ const FilterPicker = ({
   // TODO: 중복된 sort값 훅으로 분리하기
   const [searchParams] = useSearchParams();
   const sort = searchParams.get("sort") ?? "latest";
-
   const sportsIds = searchParams.get("sportsIds")?.split(",").map(Number) ?? [];
 
   return (
@@ -45,7 +44,10 @@ const FilterPicker = ({
         {sportListWithTotal.map((sport) => (
           <Filter
             key={sport.sportId}
-            $active={sportsIds.includes(sport.sportId)}
+            $active={
+              sportsIds.includes(sport.sportId) ||
+              (sportsIds.length === 0 && sport.sportId === 0)
+            }
             onClick={() => multiFilter(sport.sportId)}
           >
             {sport.sportName}

--- a/src/components/sports/SportsList.tsx
+++ b/src/components/sports/SportsList.tsx
@@ -53,12 +53,12 @@ const Sport = ({ item }: SportProps) => {
   const { sportId, sportName, sportImageUrl } = item;
   const navigate = useNavigate();
 
-  const handleLocation = (sportId: number) => {
-    navigate("/coach-list", { state: { sportId } });
+  const handleLocation = () => {
+    navigate("/coach-list");
   };
 
   return (
-    <SportStyle $id={sportId} onClick={() => handleLocation(sportId)}>
+    <SportStyle $id={sportId} onClick={handleLocation}>
       <img src={sportImageUrl} alt={sportName} />
       <p>{sportName}</p>
     </SportStyle>

--- a/src/data/sportsList.ts
+++ b/src/data/sportsList.ts
@@ -91,8 +91,8 @@ export const sportList: ICoachingSports[] = [
 ];
 
 export const filterList: IFilter[] = [
-  { id: 0, name: "최신순" },
-  { id: 1, name: "리뷰순" },
-  { id: 2, name: "좋아요순" },
-  { id: 3, name: "MY" }
+  { id: 0, name: "최신순", parameter: "latest" },
+  { id: 1, name: "리뷰순", parameter: "review" },
+  { id: 2, name: "좋아요순", parameter: "liked" },
+  { id: 3, name: "MY", parameter: "my" }
 ];

--- a/src/hooks/useCoachFilter.ts
+++ b/src/hooks/useCoachFilter.ts
@@ -1,13 +1,18 @@
+import { filterList } from "@/data/sportsList";
 import { useState } from "react";
 import toast from "react-hot-toast";
+import { useSearchParams } from "react-router-dom";
 
 const useCoachFilter = (sportId: number) => {
-  const [filterId, setFilterId] = useState<number>(0);
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const [sportsIdList, setSportsIdList] = useState<number[]>([sportId]);
 
   const singleFilter = (id: number) => {
-    setFilterId(id);
+    const sort =
+      filterList.find((filter) => filter.id === id)?.parameter ?? "latest";
+    searchParams.set("sort", sort);
+    setSearchParams(searchParams);
   };
 
   const multiFilter = (id: number) => {
@@ -29,7 +34,6 @@ const useCoachFilter = (sportId: number) => {
   };
 
   return {
-    filterId,
     sportsIdList,
     singleFilter,
     multiFilter

--- a/src/hooks/useCoachFilter.ts
+++ b/src/hooks/useCoachFilter.ts
@@ -1,12 +1,9 @@
 import { filterList } from "@/data/sportsList";
-import { useState } from "react";
 import toast from "react-hot-toast";
 import { useSearchParams } from "react-router-dom";
 
-const useCoachFilter = (sportId: number) => {
+const useCoachFilter = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-
-  const [sportsIdList, setSportsIdList] = useState<number[]>([sportId]);
 
   const singleFilter = (id: number) => {
     const sort =
@@ -16,25 +13,35 @@ const useCoachFilter = (sportId: number) => {
   };
 
   const multiFilter = (id: number) => {
-    if (sportsIdList.includes(id)) {
-      // id 제거
-      sportsIdList.length >= 2
-        ? setSportsIdList(sportsIdList.filter((sportId) => sportId !== id))
-        : toast.error("반드시 한개 이상 선택해주세요");
-    } else {
-      // id 추가
-      if (id === 0) {
-        setSportsIdList([0]);
-      } else if (sportsIdList.includes(0)) {
-        setSportsIdList([id]);
+    const sportsIds =
+      searchParams.get("sportsIds")?.split(",").map(Number) ?? [];
+
+    let newSportsIds: number[];
+
+    if (sportsIds.includes(id)) {
+      if (sportsIds.length >= 2) {
+        newSportsIds = sportsIds.filter((sportId) => sportId !== id);
       } else {
-        setSportsIdList([...sportsIdList, id]);
+        toast.error("반드시 한개 이상 선택해주세요");
+        return;
+      }
+    } else {
+      if (id === 0) {
+        newSportsIds = [];
+      } else {
+        newSportsIds = [...sportsIds, id];
       }
     }
+
+    if (newSportsIds.length === 0) {
+      searchParams.delete("sportsIds");
+    } else {
+      searchParams.set("sportsIds", newSportsIds.join(","));
+    }
+    setSearchParams(searchParams);
   };
 
   return {
-    sportsIdList,
     singleFilter,
     multiFilter
   };

--- a/src/hooks/useCoachList.ts
+++ b/src/hooks/useCoachList.ts
@@ -4,12 +4,16 @@ import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 
 const PER_PAGE = 20;
-const useCoachList = (filter: Omit<IAllCoachList, "page">, sort: string) => {
+const useCoachList = (
+  filter: Omit<IAllCoachList, "page">,
+  sort: string,
+  sportsIds: number[]
+) => {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
     useInfiniteQuery<ICoachList>({
       queryKey: ["coach-infiniteScroll", filter],
       queryFn: ({ pageParam }) =>
-        getCoachAll({ ...filter, page: pageParam as number }, sort),
+        getCoachAll({ ...filter, page: pageParam as number }, sort, sportsIds),
       getNextPageParam: (lastPage) => {
         const nextPage = lastPage.currentPage + 1;
         return lastPage.totalCount > lastPage.currentPage * PER_PAGE
@@ -21,7 +25,7 @@ const useCoachList = (filter: Omit<IAllCoachList, "page">, sort: string) => {
 
   useEffect(() => {
     refetch();
-  }, [refetch, sort]);
+  }, [refetch, sort, sportsIds]);
 
   return {
     data,

--- a/src/hooks/useCoachList.ts
+++ b/src/hooks/useCoachList.ts
@@ -1,7 +1,6 @@
 import { getCoachAll, getMyCoaches } from "@/api/coach.api";
 import { ICoachList, ISimpleCoach } from "@/models/coach.model";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
-import { useEffect } from "react";
 
 const PER_PAGE = 20;
 const useCoachList = (
@@ -22,10 +21,6 @@ const useCoachList = (
       },
       initialPageParam: 1
     });
-
-  useEffect(() => {
-    refetch();
-  }, [refetch, sort, sportsIds]);
 
   return {
     data,

--- a/src/hooks/useCoachList.ts
+++ b/src/hooks/useCoachList.ts
@@ -1,14 +1,15 @@
 import { getCoachAll, getMyCoaches } from "@/api/coach.api";
 import { IAllCoachList, ICoachList, ISimpleCoach } from "@/models/coach.model";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
 
 const PER_PAGE = 20;
-const useCoachList = (filter: Omit<IAllCoachList, "page">) => {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+const useCoachList = (filter: Omit<IAllCoachList, "page">, sort: string) => {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
     useInfiniteQuery<ICoachList>({
       queryKey: ["coach-infiniteScroll", filter],
       queryFn: ({ pageParam }) =>
-        getCoachAll({ ...filter, page: pageParam as number }),
+        getCoachAll({ ...filter, page: pageParam as number }, sort),
       getNextPageParam: (lastPage) => {
         const nextPage = lastPage.currentPage + 1;
         return lastPage.totalCount > lastPage.currentPage * PER_PAGE
@@ -18,11 +19,16 @@ const useCoachList = (filter: Omit<IAllCoachList, "page">) => {
       initialPageParam: 1
     });
 
+  useEffect(() => {
+    refetch();
+  }, [refetch, sort]);
+
   return {
     data,
     fetchNextPage,
     hasNextPage,
-    isFetchingNextPage
+    isFetchingNextPage,
+    refetch
   };
 };
 

--- a/src/hooks/useCoachList.ts
+++ b/src/hooks/useCoachList.ts
@@ -1,19 +1,19 @@
 import { getCoachAll, getMyCoaches } from "@/api/coach.api";
-import { IAllCoachList, ICoachList, ISimpleCoach } from "@/models/coach.model";
+import { ICoachList, ISimpleCoach } from "@/models/coach.model";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
 
 const PER_PAGE = 20;
 const useCoachList = (
-  filter: Omit<IAllCoachList, "page">,
+  search: string | null,
   sort: string,
   sportsIds: number[]
 ) => {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
     useInfiniteQuery<ICoachList>({
-      queryKey: ["coach-infiniteScroll", filter],
+      queryKey: ["coach-infiniteScroll", search, sort, sportsIds],
       queryFn: ({ pageParam }) =>
-        getCoachAll({ ...filter, page: pageParam as number }, sort, sportsIds),
+        getCoachAll(pageParam as number, search, sort, sportsIds),
       getNextPageParam: (lastPage) => {
         const nextPage = lastPage.currentPage + 1;
         return lastPage.totalCount > lastPage.currentPage * PER_PAGE

--- a/src/models/coach.model.ts
+++ b/src/models/coach.model.ts
@@ -36,7 +36,6 @@ export interface ICoachList {
 export interface IAllCoachList {
   filter: {
     search?: string; // 검색어
-    sportsIdList?: number[]; // 종목 필터
   };
   page: number;
 }

--- a/src/models/coach.model.ts
+++ b/src/models/coach.model.ts
@@ -36,7 +36,6 @@ export interface ICoachList {
 export interface IAllCoachList {
   filter: {
     search?: string; // 검색어
-    filterId: number; // 정렬 필터
     sportsIdList?: number[]; // 종목 필터
   };
   page: number;

--- a/src/models/sports.model.ts
+++ b/src/models/sports.model.ts
@@ -12,4 +12,5 @@ export interface ICoachingSports {
 export interface IFilter {
   id: number;
   name: string;
+  parameter: string;
 }

--- a/src/pages/CoachList.tsx
+++ b/src/pages/CoachList.tsx
@@ -3,26 +3,18 @@ import Coaches from "@/components/coach/CoachList";
 import Search from "@/components/common/InputField/search/Search";
 import useCoachFilter from "@/hooks/useCoachFilter";
 import { WhiteSpace } from "@/style/global";
-import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 
 const CoachList = () => {
-  const location = useLocation();
-  const sportId = location.state?.sportId ?? 0; // 코치 리스트를 url로 치고 들어왔을 때는 기본 종목 '전체(0)'
-
-  const { sportsIdList, singleFilter, multiFilter } = useCoachFilter(sportId);
+  const { singleFilter, multiFilter } = useCoachFilter();
 
   return (
     <CoachListStyle>
       <Search placeholder="코치명을 검색하세요" />
       <WhiteSpace $height={30} />
-      <CoachListFilter
-        sportsIdList={sportsIdList}
-        singleFilter={singleFilter}
-        multiFilter={multiFilter}
-      />
+      <CoachListFilter singleFilter={singleFilter} multiFilter={multiFilter} />
       <WhiteSpace $height={30} />
-      <Coaches sportsIdList={sportsIdList} />
+      <Coaches />
     </CoachListStyle>
   );
 };

--- a/src/pages/CoachList.tsx
+++ b/src/pages/CoachList.tsx
@@ -10,21 +10,19 @@ const CoachList = () => {
   const location = useLocation();
   const sportId = location.state?.sportId ?? 0; // 코치 리스트를 url로 치고 들어왔을 때는 기본 종목 '전체(0)'
 
-  const { filterId, sportsIdList, singleFilter, multiFilter } =
-    useCoachFilter(sportId);
+  const { sportsIdList, singleFilter, multiFilter } = useCoachFilter(sportId);
 
   return (
     <CoachListStyle>
       <Search placeholder="코치명을 검색하세요" />
       <WhiteSpace $height={30} />
       <CoachListFilter
-        filterId={filterId}
         sportsIdList={sportsIdList}
         singleFilter={singleFilter}
         multiFilter={multiFilter}
       />
       <WhiteSpace $height={30} />
-      <Coaches filterId={filterId} sportsIdList={sportsIdList} />
+      <Coaches sportsIdList={sportsIdList} />
     </CoachListStyle>
   );
 };

--- a/src/pages/CoachList.tsx
+++ b/src/pages/CoachList.tsx
@@ -11,9 +11,9 @@ const CoachList = () => {
   return (
     <CoachListStyle>
       <Search placeholder="코치명을 검색하세요" />
-      <WhiteSpace $height={30} />
+      <WhiteSpace $height={14} />
       <CoachListFilter singleFilter={singleFilter} multiFilter={multiFilter} />
-      <WhiteSpace $height={30} />
+      <WhiteSpace $height={14} />
       <Coaches />
     </CoachListStyle>
   );


### PR DESCRIPTION
# Pull requests
### 작업한 내용
-  코치 리스트 필터들을 쿼리 스트링으로 추가
-  따라서 기존에 상태에 보관했던 필터 데이터를 쿼리 스트링에서 가져오는 코드로 대체

### PR Point
- 쿼리스트링을 설정하였습니다. 
  - ex) sort = "latest"
  - ex) sportsIds = 1,2,3

### 📸 스크린샷

https://github.com/user-attachments/assets/aee81b8d-45e7-4274-b370-0c41b19d99ff



closed #185 
