### PR TITLE
Refactor: imgix (이미지 CDN)을 사용한 이미지 사이즈 최적화

### DIFF
--- a/src/components/coach/Coach.tsx
+++ b/src/components/coach/Coach.tsx
@@ -15,8 +15,9 @@ const Coach = ({ coach }: Props) => {
 
   const profileImageUrl = coach.profileImageUrl
     ? getImgixUrl(coach.profileImageUrl, {
-        w: 228,
-        h: 228,
+        w: 114, // 최대 사이즈
+        h: 114,
+        dpr: window.devicePixelRatio > 1 ? 2 : 1, // 고해상도 기기에서 2배 크기로 이미지 요청
         auth: "format"
       })
     : profilePath;

--- a/src/components/coach/Coach.tsx
+++ b/src/components/coach/Coach.tsx
@@ -1,6 +1,7 @@
 import profilePath from "@/assets/images/profile.png";
 import { ICoach } from "@/models/coach.model";
 import { LineClamp } from "@/style/global";
+import { getImgixUrl } from "@/utils/imgix";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import Heart from "../common/InputField/CheckBox/Heart";
@@ -11,9 +12,18 @@ interface Props {
 }
 const Coach = ({ coach }: Props) => {
   const navigate = useNavigate();
+
+  const profileImageUrl = coach.profileImageUrl
+    ? getImgixUrl(coach.profileImageUrl, {
+        w: 228,
+        h: 228,
+        auth: "format"
+      })
+    : profilePath;
+
   return (
     <CoachStyle onClick={() => navigate(`/coach/${coach.coachId}`)}>
-      <Image src={coach.profileImageUrl || profilePath} alt={coach.coachName} />
+      <Image src={profileImageUrl} alt={coach.coachName} />
       <Text>
         <LineClamp $line={1} className="name">
           {coach.coachName}

--- a/src/utils/imgix.ts
+++ b/src/utils/imgix.ts
@@ -1,0 +1,14 @@
+import qs from "qs";
+export const getImgixUrl = (
+  src: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params: { [key: string]: any } = {}
+): string => {
+  try {
+    const { pathname } = new URL(src);
+    qs.stringify(params);
+    return `${import.meta.env.VITE_IMGIX_CDN_URL}${pathname}?w=228&h=228&auto=format`;
+  } catch (err) {
+    return src;
+  }
+};


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- imgix (이미지 CDN)을 사용한 이미지 사이즈 최적화

### PR Point
상황 : 
![image](https://github.com/user-attachments/assets/919afc63-5906-45d2-9c46-97489913cbf9)

- imgix 홈페이지 s3 키 입력하여 사용할 수 있는 하위 도메인 추가
  - env 파일 추가(카카오톡 공유)
- Imgix와 같은 이미지 CDN을 사용하여 사용자에게 보내기 전에 특정 형태로 가공
    - 이미지 사이즈를 줄이거나 특정 포맷으로 변경하는 작업등이 가능


closed #
