### PR TITLE
Feat: 홈 API 분리 반영

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,23 +7,23 @@ import { queryClient } from "./api/queryClient";
 import Layout from "./components/layout/Layout";
 import Coach from "./pages/Coach";
 import CoachList from "./pages/CoachList";
+import First from "./pages/First";
 import Home from "./pages/Home";
 import Login from "./pages/Login";
 import Mypage from "./pages/Mypage";
 import Notification from "./pages/Notification";
+import Profile from "./pages/Profile";
 import Record from "./pages/Record";
 import RecordDatail from "./pages/RecordDatail";
+import AddRoutine from "./pages/Routine/AddRoutine";
 import CoachRoutine from "./pages/Routine/CoachRoutine";
 import MemberRoutine from "./pages/Routine/MemberRoutine";
+import MyMember from "./pages/Routine/MyMember";
+import Routine from "./pages/Routine/Routine";
 import Signup from "./pages/Signup";
+import TotalLogin from "./pages/TotalLogin";
 import { GlobalStyle } from "./style/global";
 import { theme } from "./style/theme";
-import Routine from "./pages/Routine/Routine";
-import First from "./pages/First";
-import TotalLogin from "./pages/TotalLogin";
-import AddRoutine from "./pages/Routine/AddRoutine";
-import Profile from "./pages/Profile";
-import MyMember from "./pages/Routine/MyMember";
 
 function App() {
   const router = createBrowserRouter([
@@ -121,7 +121,7 @@ const Container = styled.div`
   width: 100%;
   max-width: 600px;
   min-height: 100vh;
-  margin: 0 auto;
+  margin: 0 auto 60px;
   background-color: ${({ theme }) => theme.color.background};
 `;
 

--- a/src/api/home.api.ts
+++ b/src/api/home.api.ts
@@ -1,7 +1,17 @@
-import { IHomeData } from "@/models/home.model";
-import { requestHandler } from "./http";
 import { API_PATH } from "@/constants/apiPath";
+import { IPopularCoach } from "@/models/coach.model";
+import { IHomeData } from "@/models/home.model";
+import { ISport } from "@/models/sports.model";
+import { requestHandler } from "./http";
 
 export const getHomeData = async () => {
   return await requestHandler<IHomeData>("get", API_PATH.main);
+};
+
+export const getPopularCoaches = async () => {
+  return await requestHandler<IPopularCoach[]>("get", API_PATH.popularCoaches);
+};
+
+export const getSports = async () => {
+  return await requestHandler<ISport[]>("get", API_PATH.sports);
 };

--- a/src/api/review.api.ts
+++ b/src/api/review.api.ts
@@ -19,7 +19,7 @@ export const getReviews = async (
 export const postReview = async (coachId: number, data: IPostReview) => {
   return await requestHandler<IResponseMessage>(
     "post",
-    `coaches/${coachId}/reviews`,
+    `/v1/coaches/${coachId}/reviews`,
     data
   );
 };
@@ -27,7 +27,7 @@ export const postReview = async (coachId: number, data: IPostReview) => {
 export const editReview = async (reviewId: number, data: IPostReview) => {
   return await requestHandler<IResponseMessage>(
     "patch",
-    `coaches/reviews/${reviewId}`,
+    `/v1/coaches/reviews/${reviewId}`,
     data
   );
 };

--- a/src/components/Profile/CoachProfile.tsx
+++ b/src/components/Profile/CoachProfile.tsx
@@ -57,7 +57,7 @@ const CoachProfile = ({ coach }: CoachProfileProps) => {
           {coach.coachingSports?.map((sport) => {
             return (
               <CoachTagStyle key={sport.sportId} $id={sport.sportId as Sports}>
-                #{sport.sportName}
+                # {sport.sportName}
               </CoachTagStyle>
             );
           })}
@@ -196,6 +196,7 @@ const CoachTagsStyle = styled.div`
 const CoachTagStyle = styled.div<{ $id: Sports }>`
   display: flex;
   justify-content: center;
+  align-items: center;
   width: 13vw;
   height: 6.5vw;
   font-size: 2.5vw;

--- a/src/components/Profile/CoachProfile.tsx
+++ b/src/components/Profile/CoachProfile.tsx
@@ -51,7 +51,9 @@ const CoachProfile = ({ coach }: CoachProfileProps) => {
       <CoachProfileDetailStyle>
         <CoachNameStyle>
           <p className="name">{coach.coachName}</p>
-          <Heart id={coach.coachId} checked={coach.isLiked} size={iconSize} />
+          <div className="heart-section">
+            <Heart checked={coach.isLiked} size="20px" id={coach.coachId} />
+          </div>
         </CoachNameStyle>
         <p className="address">{coach.localAddress}</p>
         <CoachTagsStyle>
@@ -89,6 +91,20 @@ const CoachProfileStyle = styled.div`
 
     @media (max-width: 375px) {
       font-size: 16px;
+    }
+  }
+
+  .heart-section {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: #d9d9d9;
+
+    svg {
+      transform: translateY(1px);
     }
   }
 
@@ -164,6 +180,8 @@ const CoachProfileDetailStyle = styled.div`
 
 const CoachNameStyle = styled.div`
   display: flex;
+  align-items: center;
+  gap: 5px;
   margin: 4.8vw 0 0.8vw 0;
   @media (min-width: 600px) {
     margin: 30px 0 5px 0;
@@ -173,6 +191,7 @@ const CoachNameStyle = styled.div`
 const CoachTagsStyle = styled.div`
   display: flex;
   justify-content: center;
+  align-items: center;
   flex-wrap: wrap;
   gap: 10px;
 `;
@@ -180,7 +199,6 @@ const CoachTagsStyle = styled.div`
 const CoachTagStyle = styled.div<{ $id: Sports }>`
   display: flex;
   justify-content: center;
-  align-items: center;
   width: 13vw;
   height: 6.5vw;
   font-size: 2.5vw;

--- a/src/components/Profile/CoachProfile.tsx
+++ b/src/components/Profile/CoachProfile.tsx
@@ -1,5 +1,4 @@
 import profile from "@/assets/images/profile.png";
-import useResponsiveIconSize from "@/hooks/useResponsiveIconSize";
 import { IGetMyCoach } from "@/models/coach.model";
 import { isSelectProfile } from "@/store/isSelectProfile.store";
 import { useProfileInfo } from "@/store/profileInfo.store";
@@ -31,8 +30,6 @@ const CoachProfile = ({ coach }: CoachProfileProps) => {
       setProfileImageUrl(coach.profileImageUrl);
     }
   };
-
-  const iconSize = useResponsiveIconSize("16px", "24px", 375);
 
   return (
     <CoachProfileStyle>

--- a/src/components/coach/AddReview.tsx
+++ b/src/components/coach/AddReview.tsx
@@ -1,0 +1,57 @@
+import useModal from "@/hooks/useModal";
+import styled from "styled-components";
+import Modal from "../common/modal/Modal";
+import ReviewInner from "../modal/ReviewInner";
+
+interface Props {
+  coachId: number;
+  isMyReviewAdded: boolean;
+  isMatched: boolean;
+}
+
+const AddReview = ({ coachId, isMyReviewAdded, isMatched }: Props) => {
+  const { isModal, closeModal, handleModal } = useModal();
+
+  const handleEditReview = () => {
+    handleModal();
+  };
+  const buttonText = isMyReviewAdded
+    ? "내 코치님 리뷰 수정하기"
+    : "내 코치님 리뷰 작성하기";
+
+  return (
+    <>
+      <AddButton
+        className="review-add__button"
+        onClick={handleEditReview}
+        disabled={!isMatched}
+      >
+        {buttonText}
+      </AddButton>
+      {isModal && (
+        <Modal position="center" closeModal={closeModal}>
+          <ReviewInner
+            onClose={closeModal}
+            id={coachId}
+            type={isMyReviewAdded ? "edit" : "enroll"}
+          />
+        </Modal>
+      )}
+    </>
+  );
+};
+
+const AddButton = styled.button`
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 16px;
+  letter-spacing: -0.5px;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid #0075ff;
+  background-color: rgba(0, 117, 255, 0.4);
+  margin-left: auto;
+  cursor: pointer;
+`;
+
+export default AddReview;

--- a/src/components/coach/CoachDetails.tsx
+++ b/src/components/coach/CoachDetails.tsx
@@ -42,7 +42,7 @@ const CoachDetails = ({ coach }: Props) => {
 };
 
 const Details = styled.div`
-  margin-top: 20px;
+  margin: 20px 0;
 `;
 
 export default CoachDetails;

--- a/src/components/coach/CoachDetails.tsx
+++ b/src/components/coach/CoachDetails.tsx
@@ -33,7 +33,9 @@ const CoachDetails = ({ coach }: Props) => {
         {activeTabIndex === 1 && (
           <ActiveCenterMap roadNameAddress={coach.activeCenter} />
         )}
-        {activeTabIndex === 2 && <Review coachId={coach.coachId} />}
+        {activeTabIndex === 2 && (
+          <Review coachId={coach.coachId} isMatched={coach.isMatched} />
+        )}
       </Details>
     </div>
   );

--- a/src/components/coach/CoachList.tsx
+++ b/src/components/coach/CoachList.tsx
@@ -2,7 +2,7 @@ import useCoachList from "@/hooks/useCoachList";
 import useIntersectionObserver from "@/hooks/useIntersectionObserver";
 import useQueryString from "@/hooks/useQueryString";
 import styled from "styled-components";
-import Empty from "../common/Empty/Empty";
+import EmptyVersion2 from "../common/Empty/EmptyVersion2";
 import Loading from "../loading/Loading";
 import Coach from "./Coach";
 
@@ -32,12 +32,11 @@ const CoachList = () => {
           {isFetchingNextPage && <Loading textDisabled />}
         </CoachListStyle>
       ) : (
-        <Empty
-          name="list"
-          size="64px"
-          color="gray3"
-          descriptions="다른 키워드로 검색해보세요!"
-        />
+        <EmptyVersion2 imgName="warning" height="500px">
+          다른 필터로
+          <br />
+          검색해보세요
+        </EmptyVersion2>
       )}
     </>
   );

--- a/src/components/coach/PopularCoach.tsx
+++ b/src/components/coach/PopularCoach.tsx
@@ -39,7 +39,7 @@ const PopularCoach = ({ coach, index }: Props) => {
           <img src={topRanks[index]} alt={`Top${index + 1}`} />
         </div>
         <div className="heart-section">
-          <Heart checked={coach.isLiked} size="30px" id={coach.coachId} />
+          <Heart checked={coach.isLiked} size="28px" id={coach.coachId} />
         </div>
       </ProfileImage>
       <CoachDetails>

--- a/src/components/coach/PopularCoach.tsx
+++ b/src/components/coach/PopularCoach.tsx
@@ -46,7 +46,7 @@ const PopularCoach = ({ coach, index }: Props) => {
         <CoachProfileHeader>
           <CoachName>{coach.coachName}</CoachName>
           <CoachRating>
-            <SvgIcon name="star" fill="likes" width="16px" height="16px" />
+            <SvgIcon name="star" fill="review" width="16px" height="16px" />
             {coach.countOfLikes.toFixed(1)}
           </CoachRating>
         </CoachProfileHeader>

--- a/src/components/coach/PopularCoach.tsx
+++ b/src/components/coach/PopularCoach.tsx
@@ -67,6 +67,7 @@ const PopularCoach = ({ coach, index }: Props) => {
 const Wrapper = styled.div`
   display: flex;
   gap: 20px;
+  cursor: pointer;
 `;
 
 const ProfileImage = styled.div`

--- a/src/components/coach/Review.tsx
+++ b/src/components/coach/Review.tsx
@@ -10,14 +10,17 @@ import ReviewFilter from "../common/modal/contents/review/ReviewFilter";
 import Modal from "../common/modal/Modal";
 import SvgIcon from "../Icon/SvgIcon";
 import Loading from "../loading/Loading";
+import AddReview from "./AddReview";
+import ReviewCardList from "./ReviewCardList";
 
 const sortOptions: TReviewFilter[] = ["LATEST", "RATING_DESC", "RATING_ASC"];
 
 interface Props {
   coachId: number;
+  isMatched: boolean;
 }
 
-const Review = ({ coachId }: Props) => {
+const Review = ({ coachId, isMatched }: Props) => {
   const { isModal, closeModal, handleModal } = useModal();
   const [filterId, setFilterId] = useState<number>(0);
   const {
@@ -30,10 +33,10 @@ const Review = ({ coachId }: Props) => {
     setFilterId(id);
   };
 
-  const handleEditReview = () => {};
-
   if (isLoading) return <Loading />;
   if (isError || !reviews) return <Wrapper></Wrapper>;
+
+  const isMyReviewAdded = reviews.reviews.some((review) => review.isMyReview);
 
   return (
     <Wrapper>
@@ -45,9 +48,11 @@ const Review = ({ coachId }: Props) => {
           </StarWrapper>
           <span>&nbsp;&nbsp;&nbsp;리뷰{reviews.countOfReviews}개</span>
         </div>
-        <div className="review-add__button" onClick={handleEditReview}>
-          내 코치님 리뷰 수정하기
-        </div>
+        <AddReview
+          coachId={coachId}
+          isMyReviewAdded={isMyReviewAdded}
+          isMatched={isMatched}
+        />
       </Header>
       <Filter onClick={handleModal} $isActive={!!isModal}>
         {FILTER_VALUES[filterId]}
@@ -70,7 +75,7 @@ const Review = ({ coachId }: Props) => {
             등록된 리뷰가 없어요
           </EmptyVersion2>
         ) : (
-          <>hi</>
+          <ReviewCardList reviews={reviews.reviews} />
         )}
       </Contents>
     </Wrapper>
@@ -98,19 +103,6 @@ const Header = styled.div`
     line-height: 15px;
     letter-spacing: -0.5px;
   }
-
-  .review-add__button {
-    font-size: 10px;
-    font-weight: 600;
-    line-height: 16px;
-    letter-spacing: -0.5px;
-    padding: 12px;
-    border-radius: 10px;
-    border: 1px solid #0075ff;
-    background-color: rgba(0, 117, 255, 0.4);
-    margin-left: auto;
-    cursor: pointer;
-  }
 `;
 
 const StarWrapper = styled.div`
@@ -119,14 +111,7 @@ const StarWrapper = styled.div`
   gap: 2px;
 `;
 
-const Contents = styled.div`
-  background-color: #111111;
-  border-radius: 24px;
-  padding: 20px;
-  min-height: 150px;
-
-  padding: 36px 0;
-`;
+const Contents = styled.div``;
 
 const Filter = styled.div<{ $isActive: boolean }>`
   display: flex;
@@ -138,6 +123,7 @@ const Filter = styled.div<{ $isActive: boolean }>`
   font-weight: 400;
   line-height: 16px;
   letter-spacing: -0.5px;
+  cursor: pointer;
 
   ${({ $isActive }) =>
     $isActive &&

--- a/src/components/coach/Review.tsx
+++ b/src/components/coach/Review.tsx
@@ -48,11 +48,13 @@ const Review = ({ coachId, isMatched }: Props) => {
           </StarWrapper>
           <span>&nbsp;&nbsp;&nbsp;리뷰{reviews.countOfReviews}개</span>
         </div>
-        <AddReview
-          coachId={coachId}
-          isMyReviewAdded={isMyReviewAdded}
-          isMatched={isMatched}
-        />
+        {isMatched && (
+          <AddReview
+            coachId={coachId}
+            isMyReviewAdded={isMyReviewAdded}
+            isMatched={isMatched}
+          />
+        )}
       </Header>
       <Filter onClick={handleModal} $isActive={!!isModal}>
         {FILTER_VALUES[filterId]}

--- a/src/components/coach/ReviewCardList.tsx
+++ b/src/components/coach/ReviewCardList.tsx
@@ -1,0 +1,89 @@
+import { IReview } from "@/models/coach.model";
+import { timeFormat } from "@/utils/format";
+import { nameMasking } from "@/utils/masking";
+import styled from "styled-components";
+import SvgIcon from "../Icon/SvgIcon";
+
+interface Props {
+  reviews: IReview[];
+}
+const ReviewCardList = ({ reviews }: Props) => {
+  return (
+    <Wrapper>
+      {reviews.map((review) => (
+        <Card key={review.reviewId}>
+          <NameWrapper>
+            <span className="name">{nameMasking(review.userName)}</span>
+            <CoachRating>
+              <SvgIcon name="star" fill="review" width="16px" height="16px" />
+              {review.stars.toFixed(1)}
+            </CoachRating>
+          </NameWrapper>
+          <CreatedAt className="created-at">
+            {timeFormat(review.createdAt)}
+          </CreatedAt>
+          <ReviewText>{review.contents}</ReviewText>
+        </Card>
+      ))}
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+const Card = styled.div`
+  background-color: #111111;
+  border-radius: 24px;
+  padding: 20px;
+
+  position: relative;
+
+  .created-at {
+    position: absolute;
+    top: 20px;
+    right: 30px;
+  }
+`;
+
+const NameWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin: 7px;
+
+  .name {
+    font-size: 13px;
+    font-weight: 800;
+    line-height: 20px;
+    letter-spacing: -0.325px;
+  }
+`;
+
+const CoachRating = styled.div`
+  display: flex;
+  gap: 2px;
+  font-size: 10px;
+  font-weight: 400;
+  line-height: 16px;
+  letter-spacing: -0.5px;
+`;
+
+const ReviewText = styled.div`
+  font-size: 10px;
+  font-weight: 400;
+  line-height: 20px;
+  letter-spacing: -0.5px;
+  padding: 0 10px;
+`;
+
+const CreatedAt = styled.div`
+  font-size: 7px;
+  font-weight: 400;
+  line-height: 15px;
+  letter-spacing: -0.35px;
+`;
+export default ReviewCardList;

--- a/src/components/coaches/PopularCoaches.tsx
+++ b/src/components/coaches/PopularCoaches.tsx
@@ -1,15 +1,25 @@
-import { IPopularCoach } from "@/models/coach.model";
+import { useGetPopularCoaches } from "@/hooks/useHome";
 import styled from "styled-components";
 import PopularCoach from "../coach/PopularCoach";
+import EmptyVersion2 from "../common/Empty/EmptyVersion2";
+import Loading from "../loading/Loading";
 
-interface Props {
-  popularCoaches: IPopularCoach[];
-}
+const PopularCoaches = () => {
+  const { data, isLoading, isError } = useGetPopularCoaches();
 
-const PopularCoaches = ({ popularCoaches }: Props) => {
+  if (isLoading) return <Loading />;
+  if (isError || !data)
+    return (
+      <EmptyVersion2 imgName="warning" height="100px">
+        서버가
+        <br />
+        죽었어요
+      </EmptyVersion2>
+    );
+
   return (
     <Wrapper>
-      {popularCoaches?.map((coach, i) => (
+      {data?.map((coach, i) => (
         <PopularCoach key={coach.coachId} coach={coach} index={i} />
       ))}
     </Wrapper>

--- a/src/components/coaches/PopularCoaches.tsx
+++ b/src/components/coaches/PopularCoaches.tsx
@@ -31,6 +31,7 @@ const Wrapper = styled.div`
   flex-direction: column;
   gap: 18px;
   overflow: hidden;
+  padding: 30px 0;
 `;
 
 export default PopularCoaches;

--- a/src/components/common/Card/ReviewCard.tsx/RatingStars.tsx
+++ b/src/components/common/Card/ReviewCard.tsx/RatingStars.tsx
@@ -7,7 +7,6 @@ interface Props {
   onClick?: (cnt: number) => void;
 }
 
-// TODO: size 삭제
 const RatingStars = ({ stars, onClick }: Props) => {
   return (
     <>

--- a/src/components/common/InputField/CheckBox/Heart.tsx
+++ b/src/components/common/InputField/CheckBox/Heart.tsx
@@ -20,14 +20,8 @@ const Heart = ({ id, checked, size }: Props) => {
       mutateUnlike(id);
       setIsChecked(false);
     } else {
-      mutateLike(id, {
-        onSuccess: () => {
-          setIsChecked(true);
-        },
-        onError: () => {
-          setIsChecked(false);
-        }
-      });
+      mutateLike(id);
+      setIsChecked(true);
     }
   };
 

--- a/src/components/common/modal/contents/RadioContent.tsx
+++ b/src/components/common/modal/contents/RadioContent.tsx
@@ -79,12 +79,12 @@ const RadioInput = styled.input`
   }
 `;
 
-const RadioLabel = styled.span<{ $isActive: boolean }>`
+const RadioLabel = styled.p<{ $isActive: boolean }>`
   font-size: 14px;
   font-weight: 400;
   line-height: 20px;
   letter-spacing: -0.35px;
-  padding: 0.5em 1em;
+  padding: 0 1em;
   border-radius: 20px;
 `;
 

--- a/src/components/sports/SportsList.tsx
+++ b/src/components/sports/SportsList.tsx
@@ -1,21 +1,35 @@
-import { ISport } from "@/models/sports.model";
+import { useGetSports } from "@/hooks/useHome";
 import "slick-carousel/slick/slick-theme.css";
 import "slick-carousel/slick/slick.css";
 import styled from "styled-components";
+import EmptyVersion2 from "../common/Empty/EmptyVersion2";
+import Loading from "../loading/Loading";
 import HomeSport from "../sport/HomeSport";
 
 interface Props {
-  sportsList: ISport[];
   isOpen: boolean;
 }
 
-const SportsList = ({ sportsList, isOpen }: Props) => {
-  const len = isOpen ? sportsList.length : 4;
+const SportsList = ({ isOpen }: Props) => {
+  const { data, isLoading, isError } = useGetSports();
+
+  if (isLoading) return <Loading />;
+  if (isError || !data)
+    return (
+      <EmptyVersion2 imgName="warning" height="100px">
+        서버가
+        <br />
+        죽었어요
+      </EmptyVersion2>
+    );
+
+  const len = isOpen ? data.length : 4;
+
   return (
     <Wrapper>
-      {sportsList.slice(0, len).map((item) => (
-        <HomeSport key={item.sportId} item={item} />
-      ))}
+      {data
+        ?.slice(0, len)
+        .map((item) => <HomeSport key={item.sportId} item={item} />)}
     </Wrapper>
   );
 };

--- a/src/constants/apiPath.ts
+++ b/src/constants/apiPath.ts
@@ -1,5 +1,7 @@
 export const API_PATH = {
   main: "/v1/main-info",
+  popularCoaches: "/v1/popular-coaches",
+  sports: "/v1/sports",
   routine: "/v2/routines",
   userProfile: "/v1routines/user",
   category: "/v1/categories",

--- a/src/hooks/queries/useLikes.ts
+++ b/src/hooks/queries/useLikes.ts
@@ -14,6 +14,9 @@ export const useLikePost = (coachId: number) => {
     onSuccess: () => {
       toast.success("My 목록에 추가되었습니다!");
       queryClient.invalidateQueries({ queryKey: ["getCoachDetail", coachId] });
+      queryClient.invalidateQueries({ queryKey: ["coach-infiniteScroll"] });
+      queryClient.invalidateQueries({ queryKey: ["getPopularCoaches"] });
+      queryClient.invalidateQueries({ queryKey: ["getMyCoaches"] });
     }
   });
 
@@ -29,8 +32,10 @@ export const useUnLikePost = (coachId: number) => {
     mutationFn: (id: number) => unlikePost(id),
     onSuccess: () => {
       toast.success("My 목록에서 삭제되었습니다!");
-      queryClient.invalidateQueries({ queryKey: ["getHomeData"] });
       queryClient.invalidateQueries({ queryKey: ["getCoachDetail", coachId] });
+      queryClient.invalidateQueries({ queryKey: ["coach-infiniteScroll"] });
+      queryClient.invalidateQueries({ queryKey: ["getPopularCoaches"] });
+      queryClient.invalidateQueries({ queryKey: ["getMyCoaches"] });
     }
   });
 

--- a/src/hooks/useHome.ts
+++ b/src/hooks/useHome.ts
@@ -1,5 +1,7 @@
-import { getHomeData } from "@/api/home.api";
+import { getHomeData, getPopularCoaches, getSports } from "@/api/home.api";
+import { IPopularCoach } from "@/models/coach.model";
 import { IHomeData } from "@/models/home.model";
+import { ISport } from "@/models/sports.model";
 import { useQuery } from "@tanstack/react-query";
 
 const useHome = () => {
@@ -16,3 +18,29 @@ const useHome = () => {
 };
 
 export default useHome;
+
+export const useGetPopularCoaches = () => {
+  const { data, isLoading, isError } = useQuery<IPopularCoach[]>({
+    queryKey: ["getPopularCoaches"],
+    queryFn: getPopularCoaches
+  });
+
+  return {
+    data,
+    isLoading,
+    isError
+  };
+};
+
+export const useGetSports = () => {
+  const { data, isLoading, isError } = useQuery<ISport[]>({
+    queryKey: ["getSports"],
+    queryFn: getSports
+  });
+
+  return {
+    data,
+    isLoading,
+    isError
+  };
+};

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,28 +1,13 @@
 import PopularCoaches from "@/components/coaches/PopularCoaches";
-import Empty from "@/components/common/Empty/Empty";
 import SvgIcon from "@/components/Icon/SvgIcon";
-import Loading from "@/components/loading/Loading";
 import ReactHelmet from "@/components/SEO/ReactHelmet";
 import SportsList from "@/components/sports/SportsList";
-import useHome from "@/hooks/useHome";
 import { WhiteSpace } from "@/style/global";
 import { useState } from "react";
 import styled from "styled-components";
 
 const Home = () => {
-  const { data, isLoading, isError } = useHome();
   const [isOpen, setOpen] = useState(false);
-
-  if (isLoading) return <Loading />;
-  if (isError || !data)
-    return (
-      <Empty
-        name="home"
-        size="64px"
-        color="gray3"
-        descriptions="홈 화면을 가져오는 중 오류가 발생했어요."
-      />
-    );
 
   return (
     <HomeStyle>
@@ -50,7 +35,7 @@ const Home = () => {
         <Seperator />
       </SectionHeader>
       <WhiteSpace $height={30} />
-      <SportsList sportsList={data.sports} isOpen={isOpen} />
+      <SportsList isOpen={isOpen} />
       <WhiteSpace $height={55} />
       <SectionHeader>
         <Title>이번주 인기 코치</Title>
@@ -58,7 +43,7 @@ const Home = () => {
         <Seperator />
       </SectionHeader>
       <WhiteSpace $height={30} />
-      <PopularCoaches popularCoaches={data.coaches} />
+      <PopularCoaches />
       <WhiteSpace $height={20} />
     </HomeStyle>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -42,16 +42,12 @@ const Home = () => {
         <SubTitle>평점 높은 TOP3 코치를 모았어요</SubTitle>
         <Seperator />
       </SectionHeader>
-      <WhiteSpace $height={30} />
       <PopularCoaches />
-      <WhiteSpace $height={20} />
     </HomeStyle>
   );
 };
 
-const HomeStyle = styled.div`
-  padding: 0 0 60px 0;
-`;
+const HomeStyle = styled.div``;
 
 const SectionHeader = styled.div`
   display: flex;

--- a/src/utils/masking.ts
+++ b/src/utils/masking.ts
@@ -1,0 +1,8 @@
+export const nameMasking = (name: string | null): string => {
+  if (!name) {
+    return "알수없음";
+  }
+
+  const maskedPart = "*".repeat(name.length - 1);
+  return name[0] + maskedPart;
+};


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 홈 API가 인기있는 코치 API, 종목 API로 분리, 이를 반영
- 리뷰 수정, 삭제

### PR Point
- 코드 개선
  - API 분리 👉 인기있는 코치/종목 조회 API를 각 컴포넌트에서 조회
  - 리뷰 추가, 수정 버튼 컴포넌트 분리 👉 하나의 파일에서 두 개의 모달(필터 선택, 리뷰 추가)을 분리, 작성으로 개선
  - 모든 페이지에 공통적으로 margin-bottom: 60px 부여(푸터 높이)

### 📸 스크린샷
- 종목 조회
![image](https://github.com/user-attachments/assets/c9777bed-e8ae-4440-a186-2a1fa5fed5ab)
- 인기 코치 3인
![image](https://github.com/user-attachments/assets/e4c670e8-5de3-4d3e-809f-86aef6051430)
- 리뷰
![image](https://github.com/user-attachments/assets/b97fa9fb-87de-49d8-b839-dbf438632d48)

closed #366 
