### PR TITLE
Modify: 채팅 버튼 문구 등 여러가지 변경

### DIFF
--- a/src/components/coach/detail/MatchButtons.tsx
+++ b/src/components/coach/detail/MatchButtons.tsx
@@ -31,7 +31,7 @@ const MatchButtons = ({ coachId, chattingUrl, matchButtonDisabled }: Props) => {
         variant="outlined"
         onClick={handleKaKaoLink}
       >
-        카카오톡 문의하기
+        채팅 문의하기
       </CustomButton>
       <CustomButton
         size="full-sharp"

--- a/src/components/record/exerciseRecord/ExerciseCalendar.tsx
+++ b/src/components/record/exerciseRecord/ExerciseCalendar.tsx
@@ -91,6 +91,14 @@ const Wrapper = styled.div`
 `;
 
 const ResponsiveDateCalendar = styled(DateCalendar)`
+  width: 100% !important;
+
+  .MuiPickersCalendarHeader-root {
+    .MuiIconButton-root {
+      color: #878686; // 그레이 색상 추가
+    }
+  }
+
   &.MuiSvgIcon-root
     MuiSvgIcon-fontSizeMedium
     MuiPickersCalendarHeader-switchViewIcon


### PR DESCRIPTION
# Pull requests
### 작업한 내용
- 채팅 버튼 문구 등 여러가지 변경

### PR Point
- 버튼 문구를 채팅 문의하기로 변경 ( ∵ 카카오톡 문의하기  → 자체 서비스 채팅 문의)
- 달력의 좌우 화살표 버튼 색상을 그레이로 변경

### 📸 스크린샷
| 달력 화살표 버튼 색상 (그레이)                                                                    | 채팅 버튼 문구                                                                                     |
|---------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
| ![image](https://github.com/user-attachments/assets/dd5a8507-d366-4320-994a-8830849bb9d0)        | ![image](https://github.com/user-attachments/assets/b89f6918-ccb6-4644-a339-01bb459b7f26)        |



closed #이슈번호
